### PR TITLE
Fix typo in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,7 +127,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-notebooks/pratrained_models
-notebooks/pratrained_models/*
+notebooks/pretrained_models
+notebooks/pretrained_models/*
 notebooks/data
 notebooks/*.wav


### PR DESCRIPTION
There was a typo in ignoring `/pretrained_models`

Before: `/pratrained_models`

I changed it to: `/pretrained_models`